### PR TITLE
Remove automatic ADT getter definitions

### DIFF
--- a/libraries/aatree.zero
+++ b/libraries/aatree.zero
@@ -1,7 +1,8 @@
 #* aatree.zero
 
-AADatumT(a) ::= {AADatum(_level : ℕ, getValueAA : a)}
+AADatumT(a) ::= {AADatum(level : ℕ, value : a)}
 
+getValueAA(AADatum(_, value)) := value
 
 define getLevelAA(tree)
     match tree

--- a/libraries/array.zero
+++ b/libraries/array.zero
@@ -1,6 +1,6 @@
 #* array.zero
 
-ArrayT(a) ::= {Array(_size : ℕ, _data : List(ℕ && FullBinaryTree(a)))}
+ArrayT(a) ::= {Array(size : ℕ, data : List(ℕ && FullBinaryTree(a)))}
 
 newArray(xs) := Array(length(xs), newRandomAccessList(reverse(xs)))
 Array(size, data).getSize := size

--- a/libraries/prelude.zero
+++ b/libraries/prelude.zero
@@ -17,7 +17,9 @@ fix(f) ≔ 𝛚(f ∘ 𝛚) where 𝛚(x) ≔ x(x)
 𝕌 ⩴ {()}
 
 # pair
-a ⊓ b ⩴ {(first ∈ a, second ∈ b)}
+a ⊓ b ⩴ {(_ ∈ a, _ ∈ b)}
+first((a, b)) ≔ a
+second((a, b)) ≔ b
 pair(a, b) ≔ (a, b)
 swap((x, y)) ≔ (y, x)
 mapFirst(f, xy) ≔ (f(first(xy)), second(xy))
@@ -27,8 +29,8 @@ curry(f) ≔ x ↦ y ↦ f((x, y))
 uncurry(f) ≔ xx ↦ f(first(xx), second(xx))
 
 # more tuples
-Triple(a, b, c) ⩴ {(first_3 ∈ a, second_3 ∈ b, third_3 ∈ c)}
-Quadruple(a, b, c, d) ⩴ {(first_4 ∈ a, second_4 ∈ b, third_4 ∈ c, fourth_4 ∈ d)}
+Triple(a, b, c) ⩴ {(_ ∈ a, _ ∈ b, _ ∈ c)}
+Quadruple(a, b, c, d) ⩴ {(_ ∈ a, _ ∈ b, _ ∈ c, _ ∈ d)}
 
 # boolean
 𝔹 ⩴ {False, True}
@@ -59,8 +61,8 @@ mapRight(f, exy) ≔ exy.onRight(Right ∘ f)
 toMaybe ≔ Left(_) ↦ Void; Right(y) ↦ Just(y)
 
 # numbers
-ℕ ⩴ {0, ↑(_ ∈ ℕ)}
-ℤ ⩴ {+(_ ∈ ℕ), -(_ ∈ ℕ)}
+ℕ ⩴ {0, ↑(n ∈ ℕ)}
+ℤ ⩴ {+(n ∈ ℕ), -(n ∈ ℕ)}
 ℚ ⩴ {(numerator ∈ ℤ) / (denominator ∈ ℤ)}
 ↓ n ≔ n ⦊ 0 ↦ 0; ↑ n′ ↦ n′
 positive(n) ≔ + n
@@ -92,7 +94,7 @@ n ^ m ≔ m ⦊ 0 ↦ 1; ↑ m′ ↦ if isEven(m) then (n ^ (m ⫽ 2))² else n
 # n % m ≔ if m = 0 then n else (if n < m then n else (n - m) % m)
 
 # list
-List(a) ⩴ {[], (_head ∈ a) ∷ (_tail ∈ List(a))}
+List(a) ⩴ {[], (head ∈ a) ∷ (tail ∈ List(a))}
 prepend ≔ (∷)
 isNil ≔ [] ↦ True; _ ∷ _ ↦ False
 fold(f, z, xs) ≔ xs ⦊ [] ↦ z; x ∷ xs′ ↦ f(x, fold(f, z, xs′))
@@ -125,9 +127,9 @@ map(f, xs) ≔ xs.fold((∷) ∘ f, [])
 filterMap(f, xs) ≔ xs ⦊ [] ↦ []; x ∷ xs′ ↦
     (f(x) ⦊ Void ↦ xs″; Just(x′) ↦ x′ ∷ xs″ where xs″ ≔ filterMap(f, xs′))
 prune(mxs) ≔ filterMap(id, mxs)
-sequence(mxs) := mxs |> [] -> Just([]); mx :: mxs' ->
-    (mx |> Void -> Void; Just(x) ->
-        (sequence(mxs') |> Void -> Void; Just(xs) -> Just(x :: xs)))
+sequence(mxs) ≔ mxs ⦊ [] ↦ Just([]); mx ∷ mxs′ ↦
+    (mx ⦊ Void ↦ Void; Just(x) ↦
+        (sequence(mxs′) ⦊ Void ↦ Void; Just(xs) ↦ Just(x ∷ xs)))
 zipWith(f, xs, ys) ≔ xs ⦊
     [] ↦ []; x ∷ xs′ ↦ (ys ⦊ [] ↦ []; y ∷ ys′ ↦ f(x, y) ∷ zipWith(f, xs′, ys′))
 zip(xs, ys) ≔ zipWith(pair, xs, ys)
@@ -207,7 +209,7 @@ define splitWhen(p, xs)
 
 splitAt(n, xs) ≔ (xs.take(n), xs.drop(n))
 splitEvery(n, xs) ≔ if isNil(xs) then [] else
-    ys :: splitEvery(n, xs') where (ys, xs') ≔ xs.splitAt(n)
+    ys ∷ splitEvery(n, xs′) where (ys, xs′) ≔ xs.splitAt(n)
 splitOn(delimiter, ns) ≔ ns.split(startsWith(delimiter))
 
 define splitWith(splitter, ns)
@@ -270,12 +272,12 @@ parseNatural(ns) ≔ if isNil(ns) then Void else
 repl(prompt, f, input) ≔ prompt ⧺ input.lines.map(f).joinWith("\n" ⧺ prompt)
 
 # tree
-Tree(a) ⩴ {Node(_datum ∈ a, _children ∈ List(Tree(a)))}
+Tree(a) ⩴ {Node(datum ∈ a, children ∈ List(Tree(a)))}
 
 # binary tree
 BinaryTree(a) ⩴ {
     Tip,
-    Fork(_datum ∈ a, _left ∈ BinaryTree(a), _right ∈ BinaryTree(a))
+    Fork(datum ∈ a, left ∈ BinaryTree(a), right ∈ BinaryTree(a))
 }
 
 define search((≾), hash, key, tree)
@@ -296,8 +298,8 @@ define flatten(tree)
 
 # full binary tree
 FullBinaryTree(a) ⩴ {
-    Leaf(_datum ∈ a),
-    Branch(_datum ∈ a, _left ∈ FullBinaryTree(a), _right ∈ FullBinaryTree(a))
+    Leaf(datum ∈ a),
+    Branch(datum ∈ a, left ∈ FullBinaryTree(a), right ∈ FullBinaryTree(a))
 }
 
 

--- a/libraries/table.zero
+++ b/libraries/table.zero
@@ -1,7 +1,7 @@
 #* table.zero
 
 TableT(k, v) ::= {
-    Table(_compare : (k => k => 𝔹), _data : BinaryTree(AADatumT(k && v)))
+    Table(compare : (k => k => 𝔹), data : BinaryTree(AADatumT(k && v)))
 }
 
 newTable((=<), entries) := Table((=<), Tip.extendAA((=<), first, entries))

--- a/self-interpreter/ast.zero
+++ b/self-interpreter/ast.zero
@@ -6,42 +6,55 @@ ArrowType ::= {Simple, Strict, Locked, Double, Squiggle}
 SectionSide ::= {LeftSection, RightSection, LeftRightSection}
 
 StateT(ast, syntax) ::= {State(
-    getStack : List(ast),
-    getOperators : List(TableT(List(ℕ), syntax))
+    stack : List(ast),
+    operators : List(TableT(List(ℕ), syntax))
 )}
+
+getStack(State(stack, _)) := stack
+getOperators(State(_, operators)) := operators
 
 SyntaxT(ast) ::= {Syntax(
-    getAlias : List(ℕ),
-    getLeftPrecedence : ℕ,
-    getRightPrecedence : ℕ,
-    getFixity : ℕ,
-    getAssociativity : ℕ,
-    getSpecial : 𝔹,
-    getShift : (StateT(ast, SyntaxT(ast)) => ast => StateT(ast, SyntaxT(ast))),
-    getReduce : (ast => ast => ast => ast),
-    getPrior : List(ℕ)
+    alias : List(ℕ),
+    leftPrecedence : ℕ,
+    rightPrecedence : ℕ,
+    fixity : ℕ,
+    associativity : ℕ,
+    special : 𝔹,
+    shift : (StateT(ast, SyntaxT(ast)) => ast => StateT(ast, SyntaxT(ast))),
+    reduce : (ast => ast => ast => ast),
+    prior : List(ℕ)
 )}
 
+getAlias(Syntax(alias, _, _, _, _, _, _, _, _)) := alias
+getLeftPrecedence(Syntax(_, leftP, _, _, _, _, _, _, _)) := leftP
+getRightPrecedence(Syntax(_, _, rightP, _, _, _, _, _, _)) := rightP
+getFixity(Syntax(_, _, _, fixity, _, _, _, _, _)) := fixity
+getAssociativity(Syntax(_, _, _, _, assoc, _, _, _, _)) := assoc
+getSpecial(Syntax(_, _, _, _, _, special, _, _, _)) := special
+getShift(Syntax(_, _, _, _, _, _, shift, _, _)) := shift
+getReduce(Syntax(_, _, _, _, _, _, _, reduce, _)) := reduce
+getPrior(Syntax(_, _, _, _, _, _, _, _, prior)) := prior
+
 AST ::= {
-    Reference(_ : TagT, _debruijn : ℕ),
-    Arrow(_ : TagT, _type : ArrowType, _constructors : List(AST),
-        _parameter : AST, _body : AST),
-    Juxtaposition(_ : TagT, _left : AST, _right : AST),
-    Let(_ : TagT, _isTypeConstructor ∈ 𝔹,
-        _name : AST, _value : AST, _scope : AST),
-    Number(_ : TagT, _value : ℕ),
-    Operator(_ : TagT, _rank : ℕ, _syntax : SyntaxT(AST)),
-    Definition(_ : TagT, _type : DefinitionType,
-        _definiendum : AST, _definiens : AST),
-    AsPattern(_ : TagT, _left : AST, _pattern : AST),
-    CommaPair(_ : TagT, _left : AST, _right : AST),
-    Section(_ :  TagT, _side : SectionSide, _body : AST),
-    SetBuilder(_ : TagT, _forms : List(AST)),
-    ADT(_ : TagT, _parameters : List(AST), _objectType : AST),
-    Constructor(_ : TagT, _parameterTypes : List(AST), _dataType : AST,
-        _function : AST, _count : ℕ, _index : ℕ),
-    TypedNode(_ : TagT, _type : AST, _node : AST),
-    Null(_ : TagT)
+    Reference(tag : TagT, debruijn : ℕ),
+    Arrow(tag : TagT, type : ArrowType, constructors : List(AST),
+        parameter : AST, body : AST),
+    Juxtaposition(tag : TagT, left : AST, right : AST),
+    Let(tag : TagT, isTypeConstructor ∈ 𝔹,
+        name : AST, value : AST, scope : AST),
+    Number(tag : TagT, value : ℕ),
+    Operator(tag : TagT, rank : ℕ, syntax : SyntaxT(AST)),
+    Definition(tag : TagT, type : DefinitionType,
+        definiendum : AST, definiens : AST),
+    AsPattern(tag : TagT, left : AST, pattern : AST),
+    CommaPair(tag : TagT, left : AST, right : AST),
+    Section(tag : TagT, side : SectionSide, body : AST),
+    SetBuilder(tag : TagT, forms : List(AST)),
+    ADT(tag : TagT, parameters : List(AST), objectType : AST),
+    Constructor(tag : TagT, parameterTypes : List(AST), dataType : AST,
+        function : AST, count : ℕ, index : ℕ),
+    TypedNode(tag : TagT, type : AST, node : AST),
+    Null(tag : TagT)
 }
 
 define lockArrow(node)

--- a/self-interpreter/define.zero
+++ b/self-interpreter/define.zero
@@ -62,29 +62,6 @@ define isValidConstructorParameter(parameter)
     False
 
 
-define newGetterDefinition(tag, dataType, n, j, m, (parameter, k), scope)
-    if not isValidConstructorParameter(parameter)
-        syntaxError("invalid constructor parameter", parameter)
-    with parameter as Juxtaposition(_, left, returnType)
-        with left as Juxtaposition(_, _, name)
-            if isUnused(getTag(name))
-                scope
-            projector := newProjector(tag, m, k)
-            undefined' := Name(renameTag(tag, "(undefined)", NOFIX))
-            arguments := (0 .. n -- 1).map(q ->
-                if q = j then projector else undefined')
-            body := UnderscoreArrow(tag,
-                arguments.cascade(Juxtaposition(tag), Underscore(tag, 1)))
-            tag' := getTag(name)
-
-            type := getArguments(dataType).fold(ImplicitArrow,
-                DoubleArrow(dataType, returnType))
-            accessor := TypedNode(tag', type, body)
-            applyPlainDefinition(tag, name, accessor, scope)
-        syntaxError("invalid constructor parameter", parameter)
-    syntaxError("invalid constructor parameter", parameter)
-
-
 define readParameterTypes(form)
     with form as Juxtaposition(_, left, right)
         with right as Juxtaposition(_, left', right')
@@ -133,9 +110,10 @@ define newConstructorDefinition(tag, dataType, n, (form, j), scope)
     parameterTypes := readParameterTypes(form)
     constructor := Constructor(getTag(name), parameterTypes,
         dataType, body, n, j + 1)
-    scope' := applyPlainDefinition(tag, Name(getTag(name)), constructor, scope)
-    zip(parameters, 0...).fold(
-        newGetterDefinition(tag, dataType, n, j, m), scope')
+    invalidParameters := parameters.filter((not) <> isValidConstructorParameter)
+    with invalidParameters as parameter :: _
+        syntaxError("invalid constructor parameter", parameter)
+    applyPlainDefinition(tag, Name(getTag(name)), constructor, scope)
 
 
 define newFallbackCase(tag, m)

--- a/self-interpreter/lex.zero
+++ b/self-interpreter/lex.zero
@@ -7,10 +7,13 @@ POSTFIX := 3
 OPENFIX := 4
 CLOSEFIX := 5
 
-LocationT ::= {Location(_file : List(ℕ), _line : ℕ, _column : ℕ)}
-TagT ::= {
-    Tag(getTagLexeme : List(ℕ), getTagFixity : ℕ, getTagLocation : LocationT)
-}
+LocationT ::= {Location(file : List(ℕ), line : ℕ, column : ℕ)}
+
+TagT ::= {Tag(lexeme : List(ℕ), fixity : ℕ, location : LocationT)}
+
+getTagLexeme(Tag(lexeme, _, _)) := lexeme
+getTagFixity(Tag(_, fixity, _)) := fixity
+getTagLocation(Tag(_, _, location)) := location
 
 renameTag(Tag(_, _, location), lexeme, fixity) := Tag(lexeme, fixity, location)
 veil(tag) := renameTag(tag, "_", NOFIX)
@@ -130,7 +133,11 @@ TokenCode ::= {
     Space, VSpace, Newline, Symbolic, Numeric, Character, String,
     Comment, Invalid
 }
-Token ::= {Token(getTokenTag : TagT, getTokenCode : TokenCode)}
+
+TokenT ::= {Token(tag : TagT, code : TokenCode)}
+
+getTokenTag(Token(tag, _)) := tag
+getTokenCode(Token(_, code)) := code
 
 define createLineFeedToken(tag, _ @ Tag(nextLexeme, _, _))
     with nextLexeme as c :: _

--- a/self-interpreter/term.zero
+++ b/self-interpreter/term.zero
@@ -9,20 +9,23 @@ BinderVariety ::= {
 }
 
 ClosureT(term) ::= {Closure(
-    getTerm : term,
-    getEnvironment : ArrayT(ClosureT(term))
+    term : term,
+    environment : ArrayT(ClosureT(term))
 )}
 
+getTerm(Closure(term, _)) := term
+getEnvironment(Closure(_, environment)) := environment
+
 Term ::= {
-    Top(_ : TagT),
-    Constant(_ : TagT, _id : ℕ),
-    Variable(_ : TagT, _debruijn : ℕ),
-    MetaVariable(_ : TagT, _id : ℕ),
-    Binder(_ : TagT, _ : BinderVariety, _type : Term, _body : Term),
-    Application(_ : TagT, _applicand : Term, _argument : Term),
-    Construction(_ : TagT, _parameters : List(Term), _objectType : Term),
-    Numeral(_ :  TagT, _type : Term, _value : ℕ),
-    Operation(_ : TagT, _type : Term, _arity : ℕ, _operator :
+    Top(tag : TagT),
+    Constant(tag : TagT, id : ℕ),
+    Variable(tag : TagT, debruijn : ℕ),
+    MetaVariable(tag : TagT, id : ℕ),
+    Binder(tag : TagT, variety : BinderVariety, type : Term, body : Term),
+    Application(tag : TagT, applicand : Term, argument : Term),
+    Construction(tag : TagT, parameters : List(Term), objectType : Term),
+    Numeral(tag : TagT, type : Term, value : ℕ),
+    Operation(tag : TagT, type : Term, arity : ℕ, operator :
         ((ClosureT(Term) => ClosureT(Term)) =>
             List(ClosureT(Term)) => ClosureT(Term)))
 }

--- a/type-inference/show.zero
+++ b/type-inference/show.zero
@@ -1,6 +1,9 @@
 #* show.zero
 
-SchemeT(term) ::= {Scheme(getUniversals : List(term), getType : term)}
+SchemeT(term) ::= {Scheme(universals : List(term), type : term)}
+
+getUniversals(Scheme(universals, _)) := universals
+getType(Scheme(_, type)) := type
 
 
 define showScheme(Scheme(universals, term))


### PR DESCRIPTION
ADT constructor parameter names will be used only as code generator hints. Record field accessors will have to be manually defined until/unless a suitable record sugar is found.